### PR TITLE
Used already computed variable

### DIFF
--- a/ToolsForHomalg/gap/CachingObjects.gi
+++ b/ToolsForHomalg/gap/CachingObjects.gi
@@ -124,7 +124,7 @@ InstallGlobalFunction( SEARCH_WPLIST_FOR_OBJECT,
             
             obj := ElmWPObj( wp_list, pos );
             
-            if IsIdenticalObj( object, obj ) or IsEqualForCache( object, ElmWPObj( wp_list, pos ) ) then
+            if IsIdenticalObj( object, obj ) or IsEqualForCache( object, obj ) then
                 
                 return pos;
                 


### PR DESCRIPTION
Two questions:

1) Is there a deeper reason not to use the variable `obj` here?
2) Is it possible that in the function `SEARCH_WPLIST_FOR_OBJECT`,
    something similar to the bug fixed in ba8cb5559a7cdbdcdf7fef
    can happen?
